### PR TITLE
Add WASM export helpers

### DIFF
--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 # the inicated version from crates.io when published.
 # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations
 ironcalc_base = { path = "../../base", version = "0.5", features = ["use_regex_lite"] }
+ironcalc = { path = "../../xlsx", version = "0.5" }
 serde = { version = "1.0", features = ["derive"] }
 wasm-bindgen = "0.2.92"
 serde-wasm-bindgen = "0.4"

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -9,6 +9,8 @@ use ironcalc_base::{
     types::{CellType, Style},
     BorderArea, ClipboardData, UserModel as BaseModel,
 };
+use ironcalc::export::save_xlsx_to_writer;
+use std::io::{Cursor, BufWriter};
 
 fn to_js_error(error: String) -> JsError {
     JsError::new(&error.to_string())
@@ -577,6 +579,21 @@ impl Model {
     #[wasm_bindgen(js_name = "toBytes")]
     pub fn to_bytes(&self) -> Vec<u8> {
         self.model.to_bytes()
+    }
+
+    #[wasm_bindgen(js_name = "saveToCalc")]
+    pub fn save_to_calc(&self) -> Vec<u8> {
+        self.model.to_bytes()
+    }
+
+    #[wasm_bindgen(js_name = "saveToXlsx")]
+    pub fn save_to_xlsx(&self) -> Result<Vec<u8>, JsError> {
+        let mut buffer: Vec<u8> = Vec::new();
+        let cursor = Cursor::new(&mut buffer);
+        let writer = BufWriter::new(cursor);
+        save_xlsx_to_writer(&self.model, writer)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(buffer)
     }
 
     #[wasm_bindgen(js_name = "getName")]

--- a/bindings/wasm/tests/test.mjs
+++ b/bindings/wasm/tests/test.mjs
@@ -130,5 +130,21 @@ test("autofill", () => {
     assert.strictEqual(result, "23");
 });
 
+test('saveToCalc returns model bytes', () => {
+    const model = new Model('Workbook1', 'en', 'UTC');
+    model.setUserInput(0, 1, 1, '42');
+    const bytes1 = model.saveToCalc();
+    const bytes2 = model.toBytes();
+    assert.deepEqual(Array.from(bytes1), Array.from(bytes2));
+});
+
+test('saveToXlsx exports zip data', () => {
+    const model = new Model('Workbook1', 'en', 'UTC');
+    const bytes = model.saveToXlsx();
+    assert.ok(bytes.length > 4);
+    assert.strictEqual(bytes[0], 0x50); // 'P'
+    assert.strictEqual(bytes[1], 0x4b); // 'K'
+});
+
 
 


### PR DESCRIPTION
## Summary
- expose `saveToXlsx` and `saveToCalc` in WASM bindings
- depend on `ironcalc` crate to access export code
- test the new methods

## Testing
- `make -B tests` *(fails: wasm-pack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a093e9e108327a7d1292d0ac6fc67