### PR TITLE
Add tests for LEFT, RIGHT, MID and LOWER

### DIFF
--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -18,6 +18,7 @@ mod test_fn_exact;
 mod test_fn_financial;
 mod test_fn_formulatext;
 mod test_fn_if;
+mod test_fn_left_right_mid_lower;
 mod test_fn_maxifs;
 mod test_fn_minifs;
 mod test_fn_or_xor;

--- a/base/src/test/test_fn_left_right_mid_lower.rs
+++ b/base/src/test/test_fn_left_right_mid_lower.rs
@@ -1,0 +1,53 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+#[test]
+fn test_left() {
+    let mut model = new_empty_model();
+    model._set("A1", "Hello");
+    model._set("B1", "=LEFT(A1,3)");
+    model._set("B2", "=LEFT(A1)");
+    model._set("B3", "=LEFT(A1,0)");
+    model.evaluate();
+    assert_eq!(model._get_text("B1"), *"Hel");
+    assert_eq!(model._get_text("B2"), *"H");
+    assert_eq!(model._get_text("B3"), "");
+}
+
+#[test]
+fn test_right() {
+    let mut model = new_empty_model();
+    model._set("A1", "Hello");
+    model._set("B1", "=RIGHT(A1,2)");
+    model._set("B2", "=RIGHT(A1)");
+    model._set("B3", "=RIGHT(A1,0)");
+    model.evaluate();
+    assert_eq!(model._get_text("B1"), *"lo");
+    assert_eq!(model._get_text("B2"), *"o");
+    assert_eq!(model._get_text("B3"), "");
+}
+
+#[test]
+fn test_mid() {
+    let mut model = new_empty_model();
+    model._set("A1", "Hello");
+    model._set("B1", "=MID(A1,2,3)");
+    model._set("B2", "=MID(A1,1,2)");
+    model._set("B3", "=MID(A1,1,0)");
+    model.evaluate();
+    assert_eq!(model._get_text("B1"), *"ell");
+    assert_eq!(model._get_text("B2"), *"He");
+    assert_eq!(model._get_text("B3"), "");
+}
+
+#[test]
+fn test_lower() {
+    let mut model = new_empty_model();
+    model._set("A1", "Hello WORLD");
+    model._set("B1", "=LOWER(A1)");
+    model._set("B2", "=LOWER(\"TEST\")");
+    model.evaluate();
+    assert_eq!(model._get_text("B1"), *"hello world");
+    assert_eq!(model._get_text("B2"), *"test");
+}

--- a/docs/src/functions/text.md
+++ b/docs/src/functions/text.md
@@ -29,8 +29,8 @@ You can track the progress in this [GitHub issue](https://github.com/ironcalc/Ir
 | LEFTB       | <Badge type="info" text="Not implemented yet" /> | –             |
 | LEN         | <Badge type="tip" text="Available" />          | –             |
 | LENB        | <Badge type="info" text="Not implemented yet" /> | –             |
-| LOWER       | <Badge type="info" text="Not implemented yet" /> | –             |
-| MID         | <Badge type="info" text="Not implemented yet" /> | –             |
+| LOWER       | <Badge type="tip" text="Available" />          | –             |
+| MID         | <Badge type="tip" text="Available" />          | –             |
 | MIDB        | <Badge type="info" text="Not implemented yet" /> | –             |
 | NUMBERVALUE | <Badge type="info" text="Not implemented yet" /> | –             |
 | PHONETIC    | <Badge type="info" text="Not implemented yet" /> | –             |

--- a/docs/src/functions/text/left.md
+++ b/docs/src/functions/text/left.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# LEFT
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+::: 

--- a/docs/src/functions/text/lower.md
+++ b/docs/src/functions/text/lower.md
@@ -1,0 +1,11 @@
+---
+layout: doc
+outline: deep
+lang: en-US
+---
+
+# LOWER
+
+::: warning
+🚧 This function is implemented but currently lacks detailed documentation. For guidance, you may refer to the equivalent functionality in [Microsoft Excel documentation](https://support.microsoft.com/en-us/office/excel-functions-by-category-5f91f4e9-7b42-46d2-9bd1-63f26a86c0eb).
+::: 


### PR DESCRIPTION
## Summary
- add unit tests covering LEFT, RIGHT, MID, and LOWER text functions
- register the new test module

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68658d2998208327a8dceac13bfaeaa7