### PR TITLE
Implement SLOPE and INTERCEPT functions

### DIFF
--- a/base/src/expressions/parser/static_analysis.rs
+++ b/base/src/expressions/parser/static_analysis.rs
@@ -682,6 +682,8 @@ fn get_function_args_signature(kind: &Function, arg_count: usize) -> Vec<Signatu
         Function::Countifs => vec![Signature::Vector; arg_count],
         Function::Maxifs => vec![Signature::Vector; arg_count],
         Function::Minifs => vec![Signature::Vector; arg_count],
+        Function::Slope => vec![Signature::Vector; arg_count],
+        Function::Intercept => vec![Signature::Vector; arg_count],
         Function::Date => args_signature_scalars(arg_count, 3, 0),
         Function::Day => args_signature_scalars(arg_count, 1, 0),
         Function::Edate => args_signature_scalars(arg_count, 2, 0),
@@ -980,5 +982,7 @@ fn static_analysis_on_function(kind: &Function, args: &[Node]) -> StaticResult {
         Function::Eomonth => scalar_arguments(args),
         Function::Formulatext => not_implemented(args),
         Function::Geomean => not_implemented(args),
+        Function::Slope => not_implemented(args),
+        Function::Intercept => not_implemented(args),
     }
 }

--- a/base/src/functions/mod.rs
+++ b/base/src/functions/mod.rs
@@ -142,6 +142,8 @@ pub enum Function {
     Maxifs,
     Minifs,
     Geomean,
+    Slope,
+    Intercept,
 
     // Date and time
     Date,
@@ -250,7 +252,7 @@ pub enum Function {
 }
 
 impl Function {
-    pub fn into_iter() -> IntoIter<Function, 195> {
+    pub fn into_iter() -> IntoIter<Function, 197> {
         [
             Function::And,
             Function::False,
@@ -351,6 +353,8 @@ impl Function {
             Function::Maxifs,
             Function::Minifs,
             Function::Geomean,
+            Function::Slope,
+            Function::Intercept,
             Function::Year,
             Function::Day,
             Function::Month,
@@ -615,6 +619,8 @@ impl Function {
             "MAXIFS" | "_XLFN.MAXIFS" => Some(Function::Maxifs),
             "MINIFS" | "_XLFN.MINIFS" => Some(Function::Minifs),
             "GEOMEAN" => Some(Function::Geomean),
+            "SLOPE" => Some(Function::Slope),
+            "INTERCEPT" => Some(Function::Intercept),
             // Date and Time
             "YEAR" => Some(Function::Year),
             "DAY" => Some(Function::Day),
@@ -823,6 +829,8 @@ impl fmt::Display for Function {
             Function::Maxifs => write!(f, "MAXIFS"),
             Function::Minifs => write!(f, "MINIFS"),
             Function::Geomean => write!(f, "GEOMEAN"),
+            Function::Slope => write!(f, "SLOPE"),
+            Function::Intercept => write!(f, "INTERCEPT"),
             Function::Year => write!(f, "YEAR"),
             Function::Day => write!(f, "DAY"),
             Function::Month => write!(f, "MONTH"),
@@ -1060,6 +1068,8 @@ impl Model {
             Function::Maxifs => self.fn_maxifs(args, cell),
             Function::Minifs => self.fn_minifs(args, cell),
             Function::Geomean => self.fn_geomean(args, cell),
+            Function::Slope => self.fn_slope(args, cell),
+            Function::Intercept => self.fn_intercept(args, cell),
             // Date and Time
             Function::Year => self.fn_year(args, cell),
             Function::Day => self.fn_day(args, cell),

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -58,6 +58,7 @@ mod test_fn_fv;
 mod test_fn_type;
 mod test_frozen_rows_and_columns;
 mod test_geomean;
+mod test_fn_slope;
 mod test_get_cell_content;
 mod test_implicit_intersection;
 mod test_issue_155;

--- a/base/src/test/test_fn_slope.rs
+++ b/base/src/test/test_fn_slope.rs
@@ -1,0 +1,31 @@
+#![allow(clippy::unwrap_used)]
+use crate::test::util::new_empty_model;
+
+#[test]
+fn test_fn_slope_and_intercept() {
+    let mut model = new_empty_model();
+    model._set("B1", "1");
+    model._set("B2", "2");
+    model._set("B3", "3");
+    model._set("C1", "2");
+    model._set("C2", "4");
+    model._set("C3", "6");
+    model._set("A1", "=SLOPE(B1:B3,C1:C3)");
+    model._set("A2", "=INTERCEPT(B1:B3,C1:C3)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), *"0.5");
+    assert_eq!(model._get_text("A2"), *"0");
+}
+
+#[test]
+fn test_fn_slope_mismatch() {
+    let mut model = new_empty_model();
+    model._set("B1", "1");
+    model._set("B2", "2");
+    model._set("B3", "3");
+    model._set("C1", "2");
+    model._set("C2", "4");
+    model._set("A1", "=SLOPE(B1:B3,C1:C2)");
+    model.evaluate();
+    assert_eq!(model._get_text("A1"), *"#N/A");
+}


### PR DESCRIPTION
## Summary
- add SLOPE and INTERCEPT statistical functions
- support new functions in parser and dispatcher
- test slope and intercept basic usage and size mismatch

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686efd01b08c83278342441680e869ee