### PR TITLE
feat: opt-in changed-cell tracking for incremental updates

### DIFF
--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -73,6 +73,7 @@ pub use model::get_milliseconds_since_epoch;
 pub use model::FmtSettings;
 pub use model::Model;
 pub use user_model::BorderArea;
+pub use user_model::ChangedCell;
 pub use user_model::ClipboardData;
 pub use user_model::UserModel;
 pub use utils::get_all_timezones;

--- a/base/src/test/user_model/mod.rs
+++ b/base/src/test/user_model/mod.rs
@@ -5,6 +5,7 @@ mod test_autofill_columns;
 mod test_autofill_rows;
 mod test_batch_row_column_diff;
 mod test_border;
+mod test_changed_cells;
 mod test_clear_cells;
 mod test_column_style;
 mod test_conditional_formatting;

--- a/base/src/test/user_model/test_changed_cells.rs
+++ b/base/src/test/user_model/test_changed_cells.rs
@@ -1,0 +1,38 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::UserModel;
+
+#[test]
+fn tracks_only_the_changed_cells() {
+    let mut model = UserModel::new_empty("model", "en", "UTC", "en").unwrap();
+    model.set_track_changes(true);
+
+    model.set_user_input(0, 1, 1, "5").unwrap(); // A1 = 5
+    model.set_user_input(0, 1, 2, "=A1*2").unwrap(); // B1 = 10
+    model.set_user_input(0, 1, 3, "99").unwrap(); // C1 = 99
+    model.take_changed_cells(); // drain
+
+    // Editing A1 changes A1 and its dependent B1, but not C1. The result is
+    // ordered by position.
+    model.set_user_input(0, 1, 1, "6").unwrap();
+    let changed: Vec<_> = model
+        .take_changed_cells()
+        .into_iter()
+        .map(|c| (c.row, c.column, c.value))
+        .collect();
+    assert_eq!(
+        changed,
+        vec![(1, 1, "6".to_string()), (1, 2, "12".to_string())]
+    );
+
+    // Setting the same value produces no change.
+    model.set_user_input(0, 1, 1, "6").unwrap();
+    assert!(model.take_changed_cells().is_empty());
+}
+
+#[test]
+fn no_tracking_by_default() {
+    let mut model = UserModel::new_empty("model", "en", "UTC", "en").unwrap();
+    model.set_user_input(0, 1, 1, "5").unwrap();
+    assert!(model.take_changed_cells().is_empty());
+}

--- a/base/src/user_model/common.rs
+++ b/base/src/user_model/common.rs
@@ -214,6 +214,26 @@ pub struct UserModel<'a> {
     history: History,
     send_queue: Vec<QueueDiffs>,
     pause_evaluation: bool,
+    track_changes: bool,
+    /// Displayed values as of the last evaluation, used to diff the next one.
+    baseline: HashMap<(u32, i32, i32), String>,
+    /// Cells changed since the last `take_changed_cells`, keyed by position.
+    changed: HashMap<(u32, i32, i32), String>,
+}
+
+/// A cell whose displayed value changed after an evaluation, together with the
+/// new value. Produced by [`UserModel::take_changed_cells`] when change tracking
+/// is enabled.
+#[derive(Clone, Serialize)]
+pub struct ChangedCell {
+    /// Sheet index (0-indexed)
+    pub sheet: u32,
+    /// Row index
+    pub row: i32,
+    /// Column index
+    pub column: i32,
+    /// The new displayed value, empty when the cell was cleared
+    pub value: String,
 }
 
 /// Given the index of the currently selected sheet, returns the index that same
@@ -251,6 +271,9 @@ impl<'a> UserModel<'a> {
             history: History::default(),
             send_queue: vec![],
             pause_evaluation: false,
+            track_changes: false,
+            baseline: HashMap::new(),
+            changed: HashMap::new(),
         }
     }
 
@@ -270,6 +293,9 @@ impl<'a> UserModel<'a> {
             history: History::default(),
             send_queue: vec![],
             pause_evaluation: false,
+            track_changes: false,
+            baseline: HashMap::new(),
+            changed: HashMap::new(),
         })
     }
 
@@ -284,6 +310,9 @@ impl<'a> UserModel<'a> {
             history: History::default(),
             send_queue: vec![],
             pause_evaluation: false,
+            track_changes: false,
+            baseline: HashMap::new(),
+            changed: HashMap::new(),
         })
     }
 
@@ -376,13 +405,77 @@ impl<'a> UserModel<'a> {
         self.pause_evaluation = false;
     }
 
-    /// Forces an evaluation of the model
+    /// Forces an evaluation of the model, recording the changed cells against
+    /// the baseline snapshot when tracking is enabled.
     ///
     /// See also:
     /// * [Model::evaluate]
     /// * [UserModel::pause_evaluation]
     pub fn evaluate(&mut self) {
-        self.model.evaluate()
+        if !self.track_changes {
+            self.model.evaluate();
+            return;
+        }
+        self.model.evaluate();
+        let after = self.value_snapshot();
+        // Changed or newly populated cells.
+        for (position, value) in &after {
+            if self.baseline.get(position) != Some(value) {
+                self.changed.insert(*position, value.clone());
+            }
+        }
+        // Cells cleared since the baseline report an empty value.
+        for position in self.baseline.keys() {
+            if !after.contains_key(position) {
+                self.changed.insert(*position, String::new());
+            }
+        }
+        self.baseline = after;
+    }
+
+    /// Enables or disables change tracking. When enabled, edits record the cells
+    /// whose displayed value changed (including formula cascades), which can be
+    /// drained with [`UserModel::take_changed_cells`]. Disabled by default so
+    /// there is no cost for consumers that do not need it.
+    pub fn set_track_changes(&mut self, track: bool) {
+        self.track_changes = track;
+        self.changed.clear();
+        self.baseline = if track {
+            self.value_snapshot()
+        } else {
+            HashMap::new()
+        };
+    }
+
+    /// Returns the cells whose displayed value changed since the last call,
+    /// ordered by sheet, row then column, and clears the buffer. Empty unless
+    /// change tracking was enabled with [`UserModel::set_track_changes`].
+    pub fn take_changed_cells(&mut self) -> Vec<ChangedCell> {
+        let mut changed: Vec<ChangedCell> = std::mem::take(&mut self.changed)
+            .into_iter()
+            .map(|((sheet, row, column), value)| ChangedCell {
+                sheet,
+                row,
+                column,
+                value,
+            })
+            .collect();
+        changed.sort_unstable_by_key(|c| (c.sheet, c.row, c.column));
+        changed
+    }
+
+    /// Snapshot of every populated cell's displayed value, keyed by position.
+    fn value_snapshot(&self) -> HashMap<(u32, i32, i32), String> {
+        self.model
+            .get_all_cells()
+            .into_iter()
+            .filter_map(|c| {
+                self.model
+                    .get_formatted_cell_value(c.index, c.row, c.column)
+                    .ok()
+                    .map(|value| ((c.index, c.row, c.column), value))
+            })
+            .collect()
     }
 
     /// Returns the list of pending diffs and removes them from the queue
@@ -2299,7 +2392,7 @@ impl<'a> UserModel<'a> {
 
     pub(super) fn evaluate_if_not_paused(&mut self) {
         if !self.pause_evaluation {
-            self.model.evaluate();
+            self.evaluate();
         }
     }
 }

--- a/base/src/user_model/mod.rs
+++ b/base/src/user_model/mod.rs
@@ -13,6 +13,7 @@ mod sequence_detector;
 mod ui;
 mod undo_redo;
 
+pub use common::ChangedCell;
 pub use common::UserModel;
 
 #[cfg(test)]

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -184,6 +184,19 @@ impl Model {
         self.model.apply_external_diffs(diffs).map_err(to_js_error)
     }
 
+    /// Enables or disables recording the cells whose value changes on evaluation.
+    #[wasm_bindgen(js_name = "setTrackChanges")]
+    pub fn set_track_changes(&mut self, track: bool) {
+        self.model.set_track_changes(track);
+    }
+
+    /// Returns the cells changed since the last call and clears the buffer.
+    #[wasm_bindgen(js_name = "takeChangedCells", unchecked_return_type = "ChangedCell[]")]
+    pub fn take_changed_cells(&mut self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.model.take_changed_cells())
+            .map_err(|e| to_js_error(e.to_string()))
+    }
+
     #[wasm_bindgen(js_name = "getCellContent")]
     pub fn get_cell_content(&self, sheet: u32, row: i32, column: i32) -> Result<String, JsError> {
         self.model

--- a/bindings/wasm/tests/test.mjs
+++ b/bindings/wasm/tests/test.mjs
@@ -251,3 +251,20 @@ test('Cell link label and style are one undo step', () => {
     assert.strictEqual(model.getCellStyle(0, 2, 2).style.font.u, true);
     assert.strictEqual(model.getCellLink(0, 2, 2).target, "https://www.ironcalc.com/");
 });
+
+test("takeChangedCells returns only the delta", () => {
+    const model = new Model("Workbook1", "en", "UTC", "en");
+    model.setTrackChanges(true);
+    model.setUserInput(0, 1, 1, "5");        // A1 = 5
+    model.setUserInput(0, 1, 2, "=A1*2");    // B1 = 10
+    model.setUserInput(0, 1, 3, "99");       // C1 = 99
+    model.takeChangedCells();                // drain
+
+    model.setUserInput(0, 1, 1, "6");        // A1 = 6  -> A1 and B1 change, C1 does not
+    const delta = model.takeChangedCells();  // ordered by position
+    const seen = delta.map((c) => `${c.row},${c.column}=${c.value}`);
+    assert.deepEqual(seen, ["1,1=6", "1,2=12"]);
+
+    model.setUserInput(0, 1, 1, "6");        // same value -> no change
+    assert.deepEqual(model.takeChangedCells(), []);
+});

--- a/bindings/wasm/types.ts
+++ b/bindings/wasm/types.ts
@@ -134,6 +134,14 @@ export type CellArrayStructure =
   | { ArrayAnchor: [number, number] }
   | { ArrayChild: [number, number, number, number] };
 
+/** A cell whose displayed value changed after an evaluation. */
+export interface ChangedCell {
+  sheet: number;
+  row: number;
+  column: number;
+  value: string;
+}
+
 export interface WorksheetProperties {
   name: string;
   /** Tab color. Absent when Color::None. */


### PR DESCRIPTION
Draft for review against my fork's main.

Adds opt-in change tracking so consumers can get an incremental delta of the cells whose displayed value changed after each edit. This is for custom renderers and for feeding an LLM only what changed, rather than re reading the whole sheet.

### What changes

The base `UserModel` gains change tracking, exposed on the wasm bindings:

`setTrackChanges(true)` starts recording. It is off by default so there is no cost otherwise.

`takeChangedCells()` returns `ChangedCell { sheet, row, column, value }[]` since the last call, ordered by position, and clears the buffer.

### How it works

Tracking keeps a baseline snapshot of every populated cell's displayed value. After each evaluation it diffs the new snapshot against the baseline, so the result includes both the direct edit and any formula cascades. For example, editing `A1` reports `A1` and a dependent `B1`, but not unrelated cells. Cleared cells report an empty value.

### Usage

```TypeScript
model.setTrackChanges(true);
model.setUserInput(0, 1, 1, "6");     // A1 = 6
const delta = model.takeChangedCells(); // [{ ...A1, value: "6" }, { ...B1, value: "12" }]
```

### Notes

Off by default, so existing users including the web app are unaffected. While enabled, each tracked evaluation snapshots the populated cells in Rust with no JS boundary crossings. An O(changed) capture inside the evaluation loop is a possible follow up.

Tests: a native Rust test plus a wasm test asserting the delta is exactly the changed cells and empty when a value is unchanged.
