### PR TITLE
feat: incremental recalc for structural edits (stack 3/N)

### DIFF
--- a/base/src/actions.rs
+++ b/base/src/actions.rs
@@ -1,6 +1,7 @@
 use crate::cf_types::{CfRule, Cfvo};
 use crate::constants::{LAST_COLUMN, LAST_ROW};
 use crate::cut_paste::cf_sqref_anchor;
+use crate::dependency_graph::Axis;
 use crate::expressions::parser::stringify::{
     to_localized_string, to_string_displaced, DisplaceData,
 };
@@ -508,6 +509,36 @@ impl<'a> Model<'a> {
         Ok(())
     }
 
+    /// Keeps the dependency graph in step with a structural edit. A row or column
+    /// insert or delete reflects its displacement onto the graph so the next
+    /// evaluation can run incrementally. A move or cell displacement, which the
+    /// shift does not model, forces a full recompute, as does an array sheet. The
+    /// match is exhaustive so a new `DisplaceData` variant cannot silently skip
+    /// graph maintenance.
+    fn record_structural_edit(&mut self, disp: &DisplaceData) {
+        let (sheet, axis, boundary, delta) = match *disp {
+            DisplaceData::Row { sheet, row, delta } => (sheet, Axis::Row, row, delta),
+            DisplaceData::Column {
+                sheet,
+                column,
+                delta,
+            } => (sheet, Axis::Column, column, delta),
+            DisplaceData::RowMove { .. }
+            | DisplaceData::ColumnMove { .. }
+            | DisplaceData::CellHorizontal { .. }
+            | DisplaceData::CellVertical { .. } => {
+                self.graph.force_full();
+                return;
+            }
+            DisplaceData::None => return,
+        };
+        if self.array_cells.iter().any(|&(s, _, _)| s == sheet) {
+            self.graph.force_full();
+        } else {
+            self.graph.structural_edit(sheet, axis, boundary, delta);
+        }
+    }
+
     /// Inserts one or more new columns into the model at the specified index.
     ///
     /// This method shifts existing columns to the right to make space for the new columns.
@@ -572,6 +603,7 @@ impl<'a> Model<'a> {
         };
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
+        self.record_structural_edit(&disp);
 
         // In the list of columns:
         // * Keep all the columns to the left
@@ -674,6 +706,7 @@ impl<'a> Model<'a> {
         };
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
+        self.record_structural_edit(&disp);
         let worksheet = &mut self.workbook.worksheet_mut(sheet)?;
 
         // deletes all the column styles
@@ -926,6 +959,7 @@ impl<'a> Model<'a> {
         };
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
+        self.record_structural_edit(&disp);
 
         Ok(())
     }
@@ -1007,6 +1041,7 @@ impl<'a> Model<'a> {
         };
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
+        self.record_structural_edit(&disp);
         Ok(())
     }
 
@@ -1163,6 +1198,7 @@ impl<'a> Model<'a> {
         };
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
+        self.record_structural_edit(&disp);
         Ok(())
     }
 
@@ -1309,6 +1345,7 @@ impl<'a> Model<'a> {
         let disp = DisplaceData::RowMove { sheet, row, delta };
         self.displace_cells(&disp)?;
         self.displace_cf_ranges(sheet, &disp);
+        self.record_structural_edit(&disp);
         Ok(())
     }
 

--- a/base/src/dependency_graph.rs
+++ b/base/src/dependency_graph.rs
@@ -49,6 +49,89 @@ pub(crate) type Position = (u32, i32, i32);
 /// `(sheet, row1, column1, row2, column2)`.
 type Area = (u32, i32, i32, i32, i32);
 
+/// Axis a structural edit inserts or deletes lines along.
+#[derive(Clone, Copy)]
+pub(crate) enum Axis {
+    Row,
+    Column,
+}
+
+impl Axis {
+    fn coord(self, (_, row, column): Position) -> i32 {
+        match self {
+            Axis::Row => row,
+            Axis::Column => column,
+        }
+    }
+
+    fn area_max(self, (_, _, _, row2, column2): Area) -> i32 {
+        match self {
+            Axis::Row => row2,
+            Axis::Column => column2,
+        }
+    }
+
+    fn area_min(self, (_, row1, column1, _, _): Area) -> i32 {
+        match self {
+            Axis::Row => row1,
+            Axis::Column => column1,
+        }
+    }
+}
+
+/// New coordinate after inserting (`delta > 0`) or deleting (`delta < 0`)
+/// `|delta|` lines at `boundary`. `None` when the line falls inside a deleted
+/// band `[boundary, boundary - delta)`.
+fn shift_coord(x: i32, boundary: i32, delta: i32) -> Option<i32> {
+    if x < boundary {
+        Some(x)
+    } else if delta < 0 && x < boundary - delta {
+        None
+    } else {
+        Some(x + delta)
+    }
+}
+
+fn shift_position(
+    sheet: u32,
+    axis: Axis,
+    boundary: i32,
+    delta: i32,
+    pos: Position,
+) -> Option<Position> {
+    let (s, row, column) = pos;
+    if s != sheet {
+        return Some(pos);
+    }
+    match axis {
+        Axis::Row => shift_coord(row, boundary, delta).map(|r| (s, r, column)),
+        Axis::Column => shift_coord(column, boundary, delta).map(|c| (s, row, c)),
+    }
+}
+
+fn shift_area(sheet: u32, axis: Axis, boundary: i32, delta: i32, area: Area) -> Option<Area> {
+    let (s, row1, column1, row2, column2) = area;
+    if s != sheet {
+        return Some(area);
+    }
+    match axis {
+        Axis::Row => Some((
+            s,
+            shift_coord(row1, boundary, delta)?,
+            column1,
+            shift_coord(row2, boundary, delta)?,
+            column2,
+        )),
+        Axis::Column => Some((
+            s,
+            row1,
+            shift_coord(column1, boundary, delta)?,
+            row2,
+            shift_coord(column2, boundary, delta)?,
+        )),
+    }
+}
+
 /// Forward dependency edges and the pending dirty set, used to scope an
 /// incremental recompute to the cells that can change.
 #[derive(Default)]
@@ -132,6 +215,78 @@ impl DependencyGraph {
             }
         }
         affected
+    }
+
+    /// Applies a row or column insert (`delta > 0`) or delete (`delta < 0`) to
+    /// the graph: marks the dependents the edit can change, then shifts every
+    /// stored position to match the displacement so later edits still resolve.
+    /// Forces a full recompute when the shift cannot model the edit, so the
+    /// caller never has to reason about the fallback.
+    pub(crate) fn structural_edit(&mut self, sheet: u32, axis: Axis, boundary: i32, delta: i32) {
+        // A delete that shrinks a tracked range would need the range clamped;
+        // fall back to full rather than model partial-range removal.
+        if delta < 0 && self.range_overlaps_band(sheet, axis, boundary, delta) {
+            self.force_full();
+            return;
+        }
+        self.mark_structural_dependents(sheet, axis, boundary);
+        self.shift(sheet, axis, boundary, delta);
+    }
+
+    /// Marks the dependents whose value a structural edit at `boundary` can
+    /// change: those reading a moved precedent or a range reaching the boundary.
+    /// Uses pre-shift coordinates; [`shift`](Self::shift) then carries the dirty
+    /// set along with every other position.
+    fn mark_structural_dependents(&mut self, sheet: u32, axis: Axis, boundary: i32) {
+        for (precedent, dependents) in &self.cell_dependents {
+            if precedent.0 == sheet && axis.coord(*precedent) >= boundary {
+                self.dirty.extend(dependents.iter().copied());
+            }
+        }
+        for (area, dependent) in &self.range_dependents {
+            if area.0 == sheet && axis.area_max(*area) >= boundary {
+                self.dirty.insert(*dependent);
+            }
+        }
+        if !self.forced_full {
+            self.incremental_eligible = true;
+        }
+    }
+
+    fn range_overlaps_band(&self, sheet: u32, axis: Axis, boundary: i32, delta: i32) -> bool {
+        let band_end = boundary - delta - 1;
+        self.range_dependents.iter().any(|(area, _)| {
+            area.0 == sheet && axis.area_max(*area) >= boundary && axis.area_min(*area) <= band_end
+        })
+    }
+
+    /// Rewrites every stored position for a displacement at `boundary`. Edges
+    /// and ranges landing in a deleted band are dropped; the next full pass
+    /// rebuilds them.
+    fn shift(&mut self, sheet: u32, axis: Axis, boundary: i32, delta: i32) {
+        let shift_pos = |p| shift_position(sheet, axis, boundary, delta, p);
+        let mut shifted: HashMap<Position, Vec<Position>> = HashMap::new();
+        for (precedent, dependents) in self.cell_dependents.drain() {
+            let Some(precedent) = shift_pos(precedent) else {
+                continue;
+            };
+            let dependents: Vec<Position> = dependents.into_iter().filter_map(shift_pos).collect();
+            if !dependents.is_empty() {
+                shifted.entry(precedent).or_default().extend(dependents);
+            }
+        }
+        self.cell_dependents = shifted;
+        self.range_dependents = self
+            .range_dependents
+            .drain(..)
+            .filter_map(|(area, dependent)| {
+                Some((
+                    shift_area(sheet, axis, boundary, delta, area)?,
+                    shift_pos(dependent)?,
+                ))
+            })
+            .collect();
+        self.dirty = self.dirty.drain().filter_map(shift_pos).collect();
     }
 
     /// Resets pending state after a full pass, which rebuilt the edges.

--- a/base/src/test/user_model/test_incremental_recalc.rs
+++ b/base/src/test/user_model/test_incremental_recalc.rs
@@ -63,3 +63,42 @@ fn incremental_coexists_with_arrays() {
     model.evaluate();
     assert_eq!(model.get_formatted_cell_value(0, 2, 1).unwrap(), "9"); // A2 re-spilled
 }
+
+/// A row insert grows a straddling range: `SUM` is unchanged (new cells empty)
+/// while `ROWS` reflects the larger range, so the size-sensitive dependent must
+/// recompute incrementally.
+#[test]
+fn incremental_handles_row_insert() {
+    let mut model = Model::new_empty("m", "en", "UTC", "en").unwrap();
+    for row in 1..=5 {
+        model.set_user_input(0, row, 1, row.to_string()).unwrap(); // A1..A5
+    }
+    model.set_user_input(0, 1, 3, "=SUM(A1:A5)".into()).unwrap(); // C1
+    model
+        .set_user_input(0, 1, 5, "=ROWS(A1:A5)".into())
+        .unwrap(); // E1
+    model.evaluate();
+    model.set_recalc_mode(RecalcMode::Incremental);
+    model.evaluate();
+
+    model.insert_rows(0, 3, 2).unwrap(); // A1:A5 -> A1:A7
+    model.evaluate();
+    assert_eq!(model.get_formatted_cell_value(0, 1, 3).unwrap(), "15"); // SUM unchanged
+    assert_eq!(model.get_formatted_cell_value(0, 1, 5).unwrap(), "7"); // ROWS grew
+}
+
+/// A delete with no tracked range stays incremental: the referencing cell shifts
+/// up and its precedent, above the deletion, is untouched.
+#[test]
+fn incremental_handles_row_delete() {
+    let mut model = Model::new_empty("m", "en", "UTC", "en").unwrap();
+    model.set_user_input(0, 1, 1, "10".into()).unwrap(); // A1
+    model.set_user_input(0, 5, 1, "=A1+1".into()).unwrap(); // A5
+    model.evaluate();
+    model.set_recalc_mode(RecalcMode::Incremental);
+    model.evaluate();
+
+    model.delete_rows(0, 2, 1).unwrap(); // A5 -> A4, ref A1 intact
+    model.evaluate();
+    assert_eq!(model.get_formatted_cell_value(0, 4, 1).unwrap(), "11");
+}


### PR DESCRIPTION
Stacked on #84. Third in the incremental-recalc stack.

Row/column inserts and deletes previously forced a full recompute. This teaches the dependency graph to follow a structural displacement so those edits recompute incrementally.

### How

After an insert or delete, the same displacement applied to the cells and formulas is applied to the graph: every stored precedent, dependent and range coordinate is shifted, and the dependents the edit can change (those reading a moved cell or a range reaching the boundary) are marked dirty. The next evaluation then recomputes only those.

Size-sensitive formulas fall out for free: inserting inside a `SUM(A1:A5)` grows the range to `A1:A7` and its `ROWS` dependent recomputes, while `SUM` is unchanged because the new cells are empty.

### Fallback

Kept deliberately conservative, since `Full` is still the default and correctness is what matters:

- a **delete that would shrink a tracked range** falls back to full (avoids partial-range clamping),
- **moves** stay on full,
- any **sheet containing arrays or spills** stays on full.

### Safety

The whole base suite stays green under `IRONCALC_RECALC=verify`, including the insert/delete/move and array tests, plus two focused tests for the incremental insert and delete paths.
