### PR TITLE
perf: range-vertex dedup for incremental recalc (stack 4/4)

### DIFF
--- a/base/src/dependency_graph.rs
+++ b/base/src/dependency_graph.rs
@@ -138,9 +138,11 @@ fn shift_area(sheet: u32, axis: Axis, boundary: i32, delta: i32, area: Area) -> 
 pub(crate) struct DependencyGraph {
     /// Precedent cell to the cells that reference it.
     cell_dependents: HashMap<Position, Vec<Position>>,
-    /// `(range, dependent)` pairs, kept unexpanded so a `SUM` over a large range
-    /// does not create an edge per cell.
-    range_dependents: Vec<(Area, Position)>,
+    /// Distinct range to the cells that read it, kept unexpanded so a `SUM` over
+    /// a large range does not create an edge per cell. Deduplicating the range
+    /// means the affected-set walk tests each area once no matter how many
+    /// formulas share it, rather than once per referencing formula.
+    range_dependents: HashMap<Area, Vec<Position>>,
     dirty: HashSet<Position>,
     /// A value-only edit kept the graph valid, so the next evaluation may run
     /// incrementally.
@@ -171,7 +173,10 @@ impl DependencyGraph {
 
     /// Records that `dependent` reads every cell in `range`.
     pub(crate) fn add_range_edge(&mut self, range: Area, dependent: Position) {
-        self.range_dependents.push((range, dependent));
+        self.range_dependents
+            .entry(range)
+            .or_default()
+            .push(dependent);
     }
 
     /// Records a value-only edit, opting the next evaluation into incremental
@@ -208,9 +213,9 @@ impl DependencyGraph {
             if let Some(dependents) = self.cell_dependents.get(&cell) {
                 stack.extend(dependents.iter().copied());
             }
-            for (range, dependent) in &self.range_dependents {
-                if !affected.contains(dependent) && area_contains(range, cell) {
-                    stack.push(*dependent);
+            for (range, dependents) in &self.range_dependents {
+                if area_contains(range, cell) {
+                    stack.extend(dependents.iter().filter(|d| !affected.contains(d)).copied());
                 }
             }
         }
@@ -243,9 +248,9 @@ impl DependencyGraph {
                 self.dirty.extend(dependents.iter().copied());
             }
         }
-        for (area, dependent) in &self.range_dependents {
+        for (area, dependents) in &self.range_dependents {
             if area.0 == sheet && axis.area_max(*area) >= boundary {
-                self.dirty.insert(*dependent);
+                self.dirty.extend(dependents.iter().copied());
             }
         }
         if !self.forced_full {
@@ -255,7 +260,7 @@ impl DependencyGraph {
 
     fn range_overlaps_band(&self, sheet: u32, axis: Axis, boundary: i32, delta: i32) -> bool {
         let band_end = boundary - delta - 1;
-        self.range_dependents.iter().any(|(area, _)| {
+        self.range_dependents.keys().any(|area| {
             area.0 == sheet && axis.area_max(*area) >= boundary && axis.area_min(*area) <= band_end
         })
     }
@@ -276,16 +281,17 @@ impl DependencyGraph {
             }
         }
         self.cell_dependents = shifted;
-        self.range_dependents = self
-            .range_dependents
-            .drain(..)
-            .filter_map(|(area, dependent)| {
-                Some((
-                    shift_area(sheet, axis, boundary, delta, area)?,
-                    shift_pos(dependent)?,
-                ))
-            })
-            .collect();
+        let mut shifted_ranges: HashMap<Area, Vec<Position>> = HashMap::new();
+        for (area, dependents) in self.range_dependents.drain() {
+            let Some(area) = shift_area(sheet, axis, boundary, delta, area) else {
+                continue;
+            };
+            let dependents: Vec<Position> = dependents.into_iter().filter_map(shift_pos).collect();
+            if !dependents.is_empty() {
+                shifted_ranges.entry(area).or_default().extend(dependents);
+            }
+        }
+        self.range_dependents = shifted_ranges;
         self.dirty = self.dirty.drain().filter_map(shift_pos).collect();
     }
 

--- a/base/src/test/user_model/test_incremental_recalc.rs
+++ b/base/src/test/user_model/test_incremental_recalc.rs
@@ -102,3 +102,27 @@ fn incremental_handles_row_delete() {
     model.evaluate();
     assert_eq!(model.get_formatted_cell_value(0, 4, 1).unwrap(), "11");
 }
+
+/// Many formulas sharing one range collapse to a single range vertex; editing a
+/// cell inside the range still fans out to every dependent incrementally.
+#[test]
+fn incremental_shares_one_range_vertex() {
+    let mut model = Model::new_empty("m", "en", "UTC", "en").unwrap();
+    for row in 1..=10 {
+        model.set_user_input(0, row, 1, row.to_string()).unwrap(); // A1..A10
+    }
+    for row in 1..=50 {
+        model
+            .set_user_input(0, row, 3, "=SUM(A1:A10)".into())
+            .unwrap(); // C1..C50
+    }
+    model.evaluate();
+    model.set_recalc_mode(RecalcMode::Incremental);
+    model.evaluate();
+
+    model.set_user_input(0, 5, 1, "100".into()).unwrap(); // A5: 5 -> 100, sum 55 -> 150
+    model.evaluate();
+    for row in 1..=50 {
+        assert_eq!(model.get_formatted_cell_value(0, row, 3).unwrap(), "150");
+    }
+}


### PR DESCRIPTION
Stacked on #85. Fourth in the incremental-recalc stack.

The affected-set walk kept range dependents as a flat `(range, dependent)` list, so a workbook where 100 formulas read `A1:A100` stored 100 entries and re-tested that same area 100 times for every cell popped during the walk.

### How

Range dependents are now keyed by the **distinct range** (`HashMap<Area, Vec<Position>>`). Each area is a single range vertex tested once per cell, then fanning out to all the formulas that read it. This is the vertex layer of a range spanning tree: many formulas over the same table now cost one containment test instead of one per formula.

### Performance, honestly

This lowers the affected-set **scan** from O(referencing formulas) to O(distinct ranges) per cell and removes the duplicated `Area` storage. It is a complexity/memory improvement, not a headline speedup: when an edit fans out widely (one cell feeding thousands of formulas), the **recompute** cost dominates the scan, and incremental can even be slower than full there. The clear wins remain localized value edits (see #83's 509x); this PR keeps the range-heavy path from doing redundant work, it does not make wide-fanout edits cheap.

### Scope

This is the graph-side (lookup) half. The other half of HyperFormula's spanning tree, caching a range's computed value so `SUM(A1:A100)` reuses `SUM(A1:A99)`, touches the function-evaluation layer and is deliberately left as future work; it is an optimization on top of this and not needed for correctness.

### Safety

Values are unchanged; the whole base suite stays green under `IRONCALC_RECALC=verify`, plus a focused test that edits a cell shared by 50 formulas over one range and confirms every dependent updates.
