### PR TITLE
feat: recompute volatiles under incremental recalc (stack 5/6)

### DIFF
--- a/base/src/dependency_graph.rs
+++ b/base/src/dependency_graph.rs
@@ -204,8 +204,16 @@ impl DependencyGraph {
     /// Consumes the dirty set and returns every cell transitively reachable from
     /// it, including the dirty cells.
     pub(crate) fn take_affected(&mut self) -> HashSet<Position> {
+        let seeds: Vec<Position> = self.dirty.drain().collect();
+        self.reachable(seeds)
+    }
+
+    /// Every cell transitively reachable from `seeds`, including the seeds. Does
+    /// not touch the dirty set, so `Verify` can use it to find the cells a
+    /// volatile can taint.
+    pub(crate) fn reachable(&self, seeds: Vec<Position>) -> HashSet<Position> {
         let mut affected = HashSet::new();
-        let mut stack: Vec<Position> = self.dirty.drain().collect();
+        let mut stack = seeds;
         while let Some(cell) = stack.pop() {
             if !affected.insert(cell) {
                 continue;

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::vec::Vec;
 
 use crate::dependency_graph::{DependencyGraph, Position, RecalcMode};
+use crate::functions::Function;
 
 use crate::expressions::parser::static_analysis::run_static_analysis_on_node;
 use crate::{
@@ -136,6 +137,66 @@ pub struct FmtSettings {
     pub number_example: String,
 }
 
+/// Functions whose result can change without any input changing: random and
+/// clock functions, and the reference functions whose target our static edges do
+/// not capture. A cell calling one must be recomputed on every pass.
+fn is_volatile_function(kind: &Function) -> bool {
+    matches!(
+        kind,
+        Function::Rand
+            | Function::Randbetween
+            | Function::Randarray
+            | Function::Now
+            | Function::Today
+            | Function::Offset
+            | Function::Indirect
+            | Function::Cell
+            | Function::Info
+    )
+}
+
+/// Whether a formula tree calls a volatile function anywhere. The match is
+/// exhaustive so a new compound `Node` variant fails to compile until it is
+/// classified here, rather than silently reading as non-volatile.
+fn node_is_volatile(node: &Node) -> bool {
+    match node {
+        Node::FunctionKind { kind, args } => {
+            is_volatile_function(kind) || args.iter().any(node_is_volatile)
+        }
+        Node::NamedFunctionKind { args, .. } => args.iter().any(node_is_volatile),
+        Node::LambdaCallKind { lambda, args } => {
+            node_is_volatile(lambda) || args.iter().any(node_is_volatile)
+        }
+        Node::LambdaDefKind { body, .. } => node_is_volatile(body),
+        Node::OpRangeKind { left, right }
+        | Node::OpConcatenateKind { left, right }
+        | Node::OpSumKind { left, right, .. }
+        | Node::OpProductKind { left, right, .. }
+        | Node::OpPowerKind { left, right }
+        | Node::CompareKind { left, right, .. } => {
+            node_is_volatile(left) || node_is_volatile(right)
+        }
+        Node::UnaryKind { right, .. } => node_is_volatile(right),
+        Node::ImplicitIntersection { child, .. } | Node::SpillRangeOperator { child } => {
+            node_is_volatile(child)
+        }
+        Node::BooleanKind(_)
+        | Node::NumberKind(_)
+        | Node::StringKind(_)
+        | Node::ReferenceKind { .. }
+        | Node::RangeKind { .. }
+        | Node::WrongReferenceKind { .. }
+        | Node::WrongRangeKind { .. }
+        | Node::ArrayKind(_)
+        | Node::DefinedNameKind(_)
+        | Node::TableNameKind(_)
+        | Node::NamedVariableKind { .. }
+        | Node::ErrorKind(_)
+        | Node::ParseErrorKind { .. }
+        | Node::EmptyArgKind => false,
+    }
+}
+
 fn array_node_to_formula_value(node: ArrayNode) -> FormulaValue {
     match node {
         ArrayNode::Boolean(b) => FormulaValue::Boolean(b),
@@ -238,6 +299,10 @@ pub struct Model<'a> {
     /// evaluation does not model spilling, so an edit whose affected set reaches
     /// one of these falls back to a full recompute.
     pub(crate) array_cells: HashSet<Position>,
+    /// Cells whose formula calls a volatile function (`RAND`, `NOW`, `OFFSET`,
+    /// ...), computed on each full pass. A full recompute re-rolls these on every
+    /// pass, so incremental recomputes them on every edit to match.
+    pub(crate) volatile_cells: HashSet<Position>,
 }
 
 // FIXME: Maybe this should be the same as CellReference
@@ -1768,6 +1833,7 @@ impl<'a> Model<'a> {
             recalc_mode: RecalcMode::from_env(),
             recompute_scope: None,
             array_cells: HashSet::new(),
+            volatile_cells: HashSet::new(),
         };
 
         model.parse_formulas();
@@ -3037,6 +3103,27 @@ impl<'a> Model<'a> {
         self.array_cells = array_cells;
     }
 
+    /// Records the cells whose formula calls a volatile function. A full pass
+    /// re-rolls these on every evaluation; recording them lets the incremental
+    /// path recompute them on every edit so it matches that behavior.
+    fn collect_volatile_cells(&mut self) {
+        let mut volatile_cells = HashSet::new();
+        for (sheet_index, worksheet) in self.workbook.worksheets.iter().enumerate() {
+            let sheet = sheet_index as u32;
+            for (row, row_data) in &worksheet.sheet_data {
+                for (col, cell) in row_data {
+                    if let Some(formula) = cell.get_formula() {
+                        let node = &self.parsed_formulas[sheet as usize][formula as usize].0;
+                        if node_is_volatile(node) {
+                            volatile_cells.insert((sheet, *row, *col));
+                        }
+                    }
+                }
+            }
+        }
+        self.volatile_cells = volatile_cells;
+    }
+
     /// Returns all cells in the current spill area of a dynamic-formula anchor,
     /// including the anchor itself.
     fn get_spill_area(&self, cell_ref: CellReferenceIndex) -> Vec<CellReferenceIndex> {
@@ -3116,8 +3203,20 @@ impl<'a> Model<'a> {
                     let incremental = self.snapshot_values();
                     self.evaluate_full();
                     let full = self.snapshot_values();
+                    // Volatile cells and everything downstream re-roll on each
+                    // pass (RAND, NOW), so their values legitimately differ
+                    // between the two. Both passes recompute them, which is the
+                    // behavior we want; drop them and require the rest to match.
+                    let tainted = self
+                        .graph
+                        .reachable(self.volatile_cells.iter().copied().collect());
+                    let strip = |mut values: HashMap<Position, crate::cell::CellValue>| {
+                        values.retain(|position, _| !tainted.contains(position));
+                        values
+                    };
                     assert_eq!(
-                        incremental, full,
+                        strip(incremental),
+                        strip(full),
                         "incremental recalc diverged from full recompute"
                     );
                 }
@@ -3158,6 +3257,11 @@ impl<'a> Model<'a> {
         if self.graph.should_recompute_full() {
             self.evaluate_full();
             return false;
+        }
+        // Volatile cells re-roll on every full pass, so mark them dirty to
+        // recompute them (and their dependents) on every incremental pass too.
+        for &cell in &self.volatile_cells {
+            self.graph.mark_dirty(cell);
         }
         let affected = self.graph.take_affected();
         // Array and spill formulas need the full pass two-phase ordering, so an
@@ -3255,6 +3359,7 @@ impl<'a> Model<'a> {
         }
         self.evaluate_conditional_formatting();
         self.collect_array_cells();
+        self.collect_volatile_cells();
         self.graph.after_full();
     }
 

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -701,6 +701,7 @@ impl<'a> Model<'a> {
             recalc_mode: crate::RecalcMode::from_env(),
             recompute_scope: None,
             array_cells: std::collections::HashSet::new(),
+            volatile_cells: std::collections::HashSet::new(),
         };
         model.parse_formulas();
         model.evaluate_conditional_formatting();

--- a/base/src/test/user_model/test_incremental_recalc.rs
+++ b/base/src/test/user_model/test_incremental_recalc.rs
@@ -126,3 +126,25 @@ fn incremental_shares_one_range_vertex() {
         assert_eq!(model.get_formatted_cell_value(0, row, 3).unwrap(), "150");
     }
 }
+
+/// A volatile function is recomputed on every incremental edit, matching a full
+/// pass. `INDIRECT` reads its target through a string, so no static edge links
+/// the target to the reader; only volatile handling makes the reader recompute.
+#[test]
+fn incremental_recomputes_volatiles() {
+    let mut model = Model::new_empty("m", "en", "UTC", "en").unwrap();
+    model.set_user_input(0, 1, 3, "5".into()).unwrap(); // C1 = 5
+    model
+        .set_user_input(0, 1, 1, "=INDIRECT(\"C1\")".into())
+        .unwrap(); // A1 reads C1 dynamically
+    model.set_user_input(0, 1, 2, "0".into()).unwrap(); // B1 unrelated
+    model.evaluate();
+    model.set_recalc_mode(RecalcMode::Incremental);
+    model.evaluate();
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "5");
+
+    // Edit C1, A1's hidden target. Without volatile handling A1 would stay 5.
+    model.set_user_input(0, 1, 3, "99".into()).unwrap();
+    model.evaluate();
+    assert_eq!(model.get_formatted_cell_value(0, 1, 1).unwrap(), "99");
+}


### PR DESCRIPTION
Stacked on #86. Fifth in the incremental-recalc stack. **Correctness fix.**

A full recompute re-evaluates volatile functions (`RAND`, `RANDBETWEEN`, `RANDARRAY`, `NOW`, `TODAY`, `OFFSET`, `INDIRECT`, `CELL`, `INFO`) on every pass. Incremental left them frozen until an edit's affected set happened to reach them, so a workbook with `=NOW()` or `=RAND()` would show stale values, and `INDIRECT`/`OFFSET` (whose targets our static edges cannot see) would miss changes to the cells they point at.

### How

Each full pass records the cells whose formula calls a volatile function (an exhaustive `Node` walk, so a new AST variant fails to compile until classified). Before each incremental pass those cells are marked dirty, so they and their dependents recompute, exactly as a full pass would.

### Verify

`RAND`/`NOW` do not reproduce across two passes, so `Verify` (which runs incremental then full and compares) would false-fail on them. It now excludes the volatile cells and everything reachable from them, then requires the rest to match exactly. Both passes still recompute those cells, which is the behavior under test; only the non-reproducible values are dropped from the comparison.

### Tests

A deterministic regression test uses `INDIRECT("C1")`: no static edge links `C1` to the reader, so editing `C1` only updates the reader through volatile handling. Verified it fails without the fix (reads stale `5` instead of `99`). The whole base suite stays green under `IRONCALC_RECALC=verify`, including the existing `RAND`/`RANDARRAY`/`NOW` tests now that volatiles are re-evaluated.

### Known limitation

A volatile reached only through a defined name (a named formula that is itself volatile) is not detected. Direct calls, and calls nested in operators, functions, and lambdas, are.
