### PR TITLE
Cache materialized range values within a pass

### DIFF
--- a/base/src/functions/date_and_time.rs
+++ b/base/src/functions/date_and_time.rs
@@ -864,29 +864,24 @@ impl<'a> Model<'a> {
                         "Ranges are in different sheets".to_string(),
                     ));
                 }
-                for row in left.row..=right.row {
-                    for column in left.column..=right.column {
-                        match self.evaluate_cell(CellReferenceIndex {
-                            sheet: left.sheet,
-                            row,
-                            column,
-                        }) {
-                            CalcResult::Number(v) => {
-                                let serial = v.floor() as i64;
-                                self.excel_date(serial, cell)?;
-                                handle(serial)?;
-                            }
-                            CalcResult::EmptyCell => {
-                                // ignore empty cells
-                            }
-                            e @ CalcResult::Error { .. } => return Err(e),
-                            _ => {
-                                return Err(CalcResult::new_error(
-                                    Error::VALUE,
-                                    cell,
-                                    "Invalid holiday date".to_string(),
-                                ))
-                            }
+                let range_cells = self.range_values(left, right);
+                for value in range_cells.iter().flatten() {
+                    match value {
+                        CalcResult::Number(v) => {
+                            let serial = v.floor() as i64;
+                            self.excel_date(serial, cell)?;
+                            handle(serial)?;
+                        }
+                        CalcResult::EmptyCell => {
+                            // ignore empty cells
+                        }
+                        e @ CalcResult::Error { .. } => return Err(e.clone()),
+                        _ => {
+                            return Err(CalcResult::new_error(
+                                Error::VALUE,
+                                cell,
+                                "Invalid holiday date".to_string(),
+                            ))
                         }
                     }
                 }

--- a/base/src/functions/math_and_trigonometry/mathematical.rs
+++ b/base/src/functions/math_and_trigonometry/mathematical.rs
@@ -23,20 +23,15 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    result = value.min(result);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // We ignore booleans and strings
-                                }
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                result = value.min(result);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // We ignore booleans and strings
                             }
                         }
                     }
@@ -83,20 +78,15 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    result = value.max(result);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // We ignore booleans and strings
-                                }
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                result = value.max(result);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // We ignore booleans and strings
                             }
                         }
                     }
@@ -325,20 +315,16 @@ impl<'a> Model<'a> {
                             }
                         };
                     }
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    result += value;
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // We ignore booleans and strings
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                result += value;
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // We ignore booleans and strings
                             }
                         }
                     }
@@ -425,20 +411,16 @@ impl<'a> Model<'a> {
                             }
                         };
                     }
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    result += value * value;
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // We ignore booleans and strings
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                result += value * value;
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // We ignore booleans and strings
                             }
                         }
                     }
@@ -557,23 +539,17 @@ impl<'a> Model<'a> {
                             }
                         };
                     }
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            let cell_value = self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            });
-
-                            match cell_value {
-                                CalcResult::Number(value) => {
-                                    seen_value = true;
-                                    result *= value;
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // We ignore booleans and strings
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                seen_value = true;
+                                result *= value;
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // We ignore booleans and strings
                             }
                         }
                     }

--- a/base/src/functions/math_and_trigonometry/multinomial.rs
+++ b/base/src/functions/math_and_trigonometry/multinomial.rs
@@ -46,34 +46,27 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..=right.row {
-                        for column in left.column..=right.column {
-                            match self.evaluate_cell(
-                                crate::expressions::types::CellReferenceIndex {
-                                    sheet: left.sheet,
-                                    row,
-                                    column,
-                                },
-                            ) {
-                                CalcResult::Number(v) => {
-                                    if v < 0.0 {
-                                        return CalcResult::new_error(
-                                            Error::NUM,
-                                            cell,
-                                            "MULTINOMIAL requires non-negative values".to_string(),
-                                        );
-                                    }
-                                    values.push(v.trunc() as u64);
-                                }
-                                CalcResult::EmptyCell | CalcResult::EmptyArg => values.push(0),
-                                err @ CalcResult::Error { .. } => return err,
-                                _ => {
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(v) => {
+                                if *v < 0.0 {
                                     return CalcResult::new_error(
-                                        Error::VALUE,
+                                        Error::NUM,
                                         cell,
-                                        "MULTINOMIAL requires numeric values".to_string(),
-                                    )
+                                        "MULTINOMIAL requires non-negative values".to_string(),
+                                    );
                                 }
+                                values.push(v.trunc() as u64);
+                            }
+                            CalcResult::EmptyCell | CalcResult::EmptyArg => values.push(0),
+                            err @ CalcResult::Error { .. } => return err.clone(),
+                            _ => {
+                                return CalcResult::new_error(
+                                    Error::VALUE,
+                                    cell,
+                                    "MULTINOMIAL requires numeric values".to_string(),
+                                )
                             }
                         }
                     }

--- a/base/src/functions/statistical/count_and_average.rs
+++ b/base/src/functions/statistical/count_and_average.rs
@@ -69,26 +69,21 @@ impl<'a> Model<'a> {
                         ));
                     }
 
-                    for row in left.row..=right.row {
-                        for column in left.column..=right.column {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    f(value);
-                                }
-                                error @ CalcResult::Error { .. } => return Err(error),
-                                CalcResult::Range { .. } => {
-                                    return Err(CalcResult::new_error(
-                                        Error::ERROR,
-                                        cell,
-                                        "Unexpected Range".to_string(),
-                                    ));
-                                }
-                                _ => {}
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                f(*value);
                             }
+                            error @ CalcResult::Error { .. } => return Err(error.clone()),
+                            CalcResult::Range { .. } => {
+                                return Err(CalcResult::new_error(
+                                    Error::ERROR,
+                                    cell,
+                                    "Unexpected Range".to_string(),
+                                ));
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -163,32 +158,27 @@ impl<'a> Model<'a> {
                         ));
                     }
 
-                    for row in left.row..=right.row {
-                        for column in left.column..=right.column {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    f(value);
-                                }
-                                CalcResult::Boolean(b) => {
-                                    f(if b { 1.0 } else { 0.0 });
-                                }
-                                CalcResult::String(_) => {
-                                    f(0.0);
-                                }
-                                error @ CalcResult::Error { .. } => return Err(error),
-                                CalcResult::Range { .. } => {
-                                    return Err(CalcResult::new_error(
-                                        Error::ERROR,
-                                        cell,
-                                        "Unexpected Range".to_string(),
-                                    ));
-                                }
-                                _ => {}
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                f(*value);
                             }
+                            CalcResult::Boolean(b) => {
+                                f(if *b { 1.0 } else { 0.0 });
+                            }
+                            CalcResult::String(_) => {
+                                f(0.0);
+                            }
+                            error @ CalcResult::Error { .. } => return Err(error.clone()),
+                            CalcResult::Range { .. } => {
+                                return Err(CalcResult::new_error(
+                                    Error::ERROR,
+                                    cell,
+                                    "Unexpected Range".to_string(),
+                                ));
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -240,39 +230,34 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::String(_) => count += 1.0,
-                                CalcResult::Number(value) => {
-                                    count += 1.0;
-                                    sum += value;
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::String(_) => count += 1.0,
+                            CalcResult::Number(value) => {
+                                count += 1.0;
+                                sum += value;
+                            }
+                            CalcResult::Boolean(b) => {
+                                if *b {
+                                    sum += 1.0;
                                 }
-                                CalcResult::Boolean(b) => {
-                                    if b {
-                                        sum += 1.0;
-                                    }
-                                    count += 1.0;
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                CalcResult::Range { .. } => {
-                                    return CalcResult::new_error(
-                                        Error::ERROR,
-                                        cell,
-                                        "Unexpected Range".to_string(),
-                                    );
-                                }
-                                CalcResult::EmptyCell | CalcResult::EmptyArg => {}
-                                CalcResult::Array(_) | CalcResult::Lambda(_) => {
-                                    return CalcResult::Error {
-                                        error: Error::NIMPL,
-                                        origin: cell,
-                                        message: "Arrays not supported yet".to_string(),
-                                    }
+                                count += 1.0;
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            CalcResult::Range { .. } => {
+                                return CalcResult::new_error(
+                                    Error::ERROR,
+                                    cell,
+                                    "Unexpected Range".to_string(),
+                                );
+                            }
+                            CalcResult::EmptyCell | CalcResult::EmptyArg => {}
+                            CalcResult::Array(_) | CalcResult::Lambda(_) => {
+                                return CalcResult::Error {
+                                    error: Error::NIMPL,
+                                    origin: cell,
+                                    message: "Arrays not supported yet".to_string(),
                                 }
                             }
                         }
@@ -350,15 +335,10 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
-                            if let CalcResult::Number(_) = self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                result += 1.0;
-                            }
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        if let CalcResult::Number(_) = value {
+                            result += 1.0;
                         }
                     }
                 }
@@ -386,17 +366,12 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::EmptyCell | CalcResult::EmptyArg => {}
-                                _ => {
-                                    result += 1.0;
-                                }
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::EmptyCell | CalcResult::EmptyArg => {}
+                            _ => {
+                                result += 1.0;
                             }
                         }
                     }
@@ -516,20 +491,16 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..=row2 {
-                        for column in column1..=column2 {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut values, &mut sum, &mut count, value);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut values, &mut sum, &mut count, *value);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric
                             }
                         }
                     }

--- a/base/src/functions/statistical/devsq.rs
+++ b/base/src/functions/statistical/devsq.rs
@@ -67,20 +67,16 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // We ignore booleans and strings
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // We ignore booleans and strings
                             }
                         }
                     }

--- a/base/src/functions/statistical/standard_dev.rs
+++ b/base/src/functions/statistical/standard_dev.rs
@@ -66,20 +66,16 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric
                             }
                         }
                     }
@@ -191,20 +187,16 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric
                             }
                         }
                     }
@@ -315,27 +307,23 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                CalcResult::String(_) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, 0.0);
-                                }
-                                CalcResult::Boolean(value) => {
-                                    let val = if value { 1.0 } else { 0.0 };
-                                    accumulate(&mut sum, &mut sumsq, &mut count, val);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric for now
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            CalcResult::String(_) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, 0.0);
+                            }
+                            CalcResult::Boolean(value) => {
+                                let val = if *value { 1.0 } else { 0.0 };
+                                accumulate(&mut sum, &mut sumsq, &mut count, val);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric for now
                             }
                         }
                     }
@@ -446,27 +434,23 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                CalcResult::String(_) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, 0.0);
-                                }
-                                CalcResult::Boolean(value) => {
-                                    let val = if value { 1.0 } else { 0.0 };
-                                    accumulate(&mut sum, &mut sumsq, &mut count, val);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric for now
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            CalcResult::String(_) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, 0.0);
+                            }
+                            CalcResult::Boolean(value) => {
+                                let val = if *value { 1.0 } else { 0.0 };
+                                accumulate(&mut sum, &mut sumsq, &mut count, val);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric for now
                             }
                         }
                     }

--- a/base/src/functions/statistical/variance.rs
+++ b/base/src/functions/statistical/variance.rs
@@ -66,20 +66,16 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric
                             }
                         }
                     }
@@ -190,20 +186,16 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric
                             }
                         }
                     }
@@ -314,27 +306,23 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..=row2 {
-                        for column in column1..=column2 {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                CalcResult::String(_) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, 0.0);
-                                }
-                                CalcResult::Boolean(value) => {
-                                    let val = if value { 1.0 } else { 0.0 };
-                                    accumulate(&mut sum, &mut sumsq, &mut count, val);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric for now (A semantics to be added)
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            CalcResult::String(_) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, 0.0);
+                            }
+                            CalcResult::Boolean(value) => {
+                                let val = if *value { 1.0 } else { 0.0 };
+                                accumulate(&mut sum, &mut sumsq, &mut count, val);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric for now (A semantics to be added)
                             }
                         }
                     }
@@ -445,27 +433,23 @@ impl<'a> Model<'a> {
                         };
                     }
 
-                    for row in row1..row2 + 1 {
-                        for column in column1..(column2 + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::Number(value) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, value);
-                                }
-                                CalcResult::String(_) => {
-                                    accumulate(&mut sum, &mut sumsq, &mut count, 0.0);
-                                }
-                                CalcResult::Boolean(value) => {
-                                    let val = if value { 1.0 } else { 0.0 };
-                                    accumulate(&mut sum, &mut sumsq, &mut count, val);
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                _ => {
-                                    // ignore non-numeric for now
-                                }
+                    let range_cells =
+                        self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::Number(value) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, *value);
+                            }
+                            CalcResult::String(_) => {
+                                accumulate(&mut sum, &mut sumsq, &mut count, 0.0);
+                            }
+                            CalcResult::Boolean(value) => {
+                                let val = if *value { 1.0 } else { 0.0 };
+                                accumulate(&mut sum, &mut sumsq, &mut count, val);
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            _ => {
+                                // ignore non-numeric for now
                             }
                         }
                     }

--- a/base/src/functions/subtotal.rs
+++ b/base/src/functions/subtotal.rs
@@ -147,7 +147,10 @@ impl<'a> Model<'a> {
                             let column1 = left.column;
                             let column2 = right.column;
 
-                            for row in row1..=row2 {
+                            let range_cells =
+                                self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                            for (row_index, row_values) in range_cells.iter().enumerate() {
+                                let row = row1 + row_index as i32;
                                 let cell_status = self
                                     .cell_hidden_status(left.sheet, row, column1)
                                     .map_err(|message| {
@@ -161,19 +164,18 @@ impl<'a> Model<'a> {
                                 {
                                     continue;
                                 }
-                                for column in column1..=column2 {
+                                for (column_index, value) in row_values.iter().enumerate() {
+                                    let column = column1 + column_index as i32;
                                     if self.cell_is_subtotal(left.sheet, row, column) {
                                         continue;
                                     }
-                                    match self.evaluate_cell(CellReferenceIndex {
-                                        sheet: left.sheet,
-                                        row,
-                                        column,
-                                    }) {
+                                    match value {
                                         CalcResult::Number(value) => {
-                                            result.push(value);
+                                            result.push(*value);
                                         }
-                                        error @ CalcResult::Error { .. } => return Err(error),
+                                        error @ CalcResult::Error { .. } => {
+                                            return Err(error.clone())
+                                        }
                                         _ => {
                                             // We ignore booleans and strings
                                         }
@@ -395,7 +397,10 @@ impl<'a> Model<'a> {
                             let column1 = left.column;
                             let column2 = right.column;
 
-                            for row in row1..=row2 {
+                            let range_cells =
+                                self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                            for (row_index, row_values) in range_cells.iter().enumerate() {
+                                let row = row1 + row_index as i32;
                                 let cell_status = match self
                                     .cell_hidden_status(left.sheet, row, column1)
                                 {
@@ -412,15 +417,12 @@ impl<'a> Model<'a> {
                                 {
                                     continue;
                                 }
-                                for column in column1..=column2 {
+                                for (column_index, value) in row_values.iter().enumerate() {
+                                    let column = column1 + column_index as i32;
                                     if self.cell_is_subtotal(left.sheet, row, column) {
                                         continue;
                                     }
-                                    match self.evaluate_cell(CellReferenceIndex {
-                                        sheet: left.sheet,
-                                        row,
-                                        column,
-                                    }) {
+                                    match value {
                                         CalcResult::EmptyCell | CalcResult::EmptyArg => {
                                             // skip
                                         }
@@ -478,7 +480,10 @@ impl<'a> Model<'a> {
                             let column1 = left.column;
                             let column2 = right.column;
 
-                            for row in row1..=row2 {
+                            let range_cells =
+                                self.range_values_rect(left.sheet, row1, column1, row2, column2);
+                            for (row_index, row_values) in range_cells.iter().enumerate() {
+                                let row = row1 + row_index as i32;
                                 let cell_status = match self
                                     .cell_hidden_status(left.sheet, row, column1)
                                 {
@@ -495,17 +500,12 @@ impl<'a> Model<'a> {
                                 {
                                     continue;
                                 }
-                                for column in column1..=column2 {
+                                for (column_index, value) in row_values.iter().enumerate() {
+                                    let column = column1 + column_index as i32;
                                     if self.cell_is_subtotal(left.sheet, row, column) {
                                         continue;
                                     }
-                                    if let CalcResult::Number(_) =
-                                        self.evaluate_cell(CellReferenceIndex {
-                                            sheet: left.sheet,
-                                            row,
-                                            column,
-                                        })
-                                    {
+                                    if let CalcResult::Number(_) = value {
                                         count += 1;
                                     }
                                 }

--- a/base/src/functions/text/common.rs
+++ b/base/src/functions/text/common.rs
@@ -225,33 +225,28 @@ impl<'a> Model<'a> {
                             "Ranges are in different sheets".to_string(),
                         );
                     }
-                    for row in left.row..(right.row + 1) {
-                        for column in left.column..(right.column + 1) {
-                            match self.evaluate_cell(CellReferenceIndex {
-                                sheet: left.sheet,
-                                row,
-                                column,
-                            }) {
-                                CalcResult::String(value) => {
-                                    result = format!("{result}{value}");
+                    let range_cells = self.range_values(left, right);
+                    for value in range_cells.iter().flatten() {
+                        match value {
+                            CalcResult::String(value) => {
+                                result = format!("{result}{value}");
+                            }
+                            CalcResult::Number(value) => result = format!("{result}{value}"),
+                            CalcResult::Boolean(value) => {
+                                if *value {
+                                    result = format!("{result}TRUE");
+                                } else {
+                                    result = format!("{result}FALSE");
                                 }
-                                CalcResult::Number(value) => result = format!("{result}{value}"),
-                                CalcResult::Boolean(value) => {
-                                    if value {
-                                        result = format!("{result}TRUE");
-                                    } else {
-                                        result = format!("{result}FALSE");
-                                    }
-                                }
-                                error @ CalcResult::Error { .. } => return error,
-                                CalcResult::EmptyCell | CalcResult::EmptyArg => {}
-                                CalcResult::Range { .. } => {}
-                                CalcResult::Array(_) | CalcResult::Lambda(_) => {
-                                    return CalcResult::Error {
-                                        error: Error::NIMPL,
-                                        origin: cell,
-                                        message: "Arrays not supported yet".to_string(),
-                                    }
+                            }
+                            error @ CalcResult::Error { .. } => return error.clone(),
+                            CalcResult::EmptyCell | CalcResult::EmptyArg => {}
+                            CalcResult::Range { .. } => {}
+                            CalcResult::Array(_) | CalcResult::Lambda(_) => {
+                                return CalcResult::Error {
+                                    error: Error::NIMPL,
+                                    origin: cell,
+                                    message: "Arrays not supported yet".to_string(),
                                 }
                             }
                         }

--- a/base/src/model.rs
+++ b/base/src/model.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::vec::Vec;
 
 use crate::expressions::parser::static_analysis::run_static_analysis_on_node;
@@ -175,6 +176,10 @@ pub(crate) enum CellOrRange {
     Range((u32, i32, i32, i32, i32)),
 }
 
+/// Materialized values of a rectangular range, shared across the formulas that
+/// read it in a pass. See [`Model::range_values`].
+pub(crate) type RangeValues = Arc<Vec<Vec<CalcResult>>>;
+
 /// A dynamical IronCalc model.
 ///
 /// Its is composed of a `Workbook`. Everything else are dynamical quantities:
@@ -225,6 +230,14 @@ pub struct Model<'a> {
     pub(crate) cf_cache: HashMap<(u32, i32, i32), Vec<CfCellResult>>,
     /// Dynamic links: links created by formulas like HYPERLINK
     pub(crate) links: HashMap<(u32, i32, i32), Link>,
+    /// Materialized cell values per range, valid only within a single pass:
+    /// cleared at the pass start and end, and on each spill restart so a range
+    /// materialized under a superseded order is never reused. A column of
+    /// `SUM(A1:A10000)` then reads the range once instead of once per formula.
+    /// Shared through `Arc` so a cache hit is a refcount bump. Trades memory for
+    /// speed: peak memory scales with the distinct ranges read in the pass, not
+    /// the largest one.
+    pub(crate) range_cache: HashMap<(u32, i32, i32, i32, i32), RangeValues>,
 }
 
 // FIXME: Maybe this should be the same as CellReference
@@ -1364,6 +1377,74 @@ impl<'a> Model<'a> {
         self.workbook.worksheet(sheet)?.is_empty_cell(row, column)
     }
 
+    /// Materialized values of a rectangular range, cached for the pass. Every
+    /// cell is evaluated on demand, and repeated reads of the same range reuse
+    /// the `Arc`, so a column of aggregates over one range reads it once.
+    pub(crate) fn range_values(
+        &mut self,
+        left: CellReferenceIndex,
+        right: CellReferenceIndex,
+    ) -> RangeValues {
+        // Clamp an open range (one ending at the last row/column, e.g. A:A or
+        // the skip-header A2:A1048576) to the used area so it does not
+        // materialize a million empty cells. Blank-counting functions
+        // (COUNTBLANK, TEXTJOIN) keep direct reads, since for them the trailing
+        // blanks are significant.
+        let (mut row2, mut column2) = (right.row, right.column);
+        if let Ok(worksheet) = self.workbook.worksheet(left.sheet) {
+            let dimension = worksheet.dimension();
+            if row2 == LAST_ROW {
+                row2 = dimension.max_row;
+            }
+            if column2 == LAST_COLUMN {
+                column2 = dimension.max_column;
+            }
+        }
+        let key = (left.sheet, left.row, left.column, row2, column2);
+        if let Some(hit) = self.range_cache.get(&key) {
+            return hit.clone();
+        }
+        let mut rows = Vec::with_capacity((row2 - left.row + 1).max(0) as usize);
+        for row in left.row..=row2 {
+            let mut columns = Vec::with_capacity((column2 - left.column + 1).max(0) as usize);
+            for column in left.column..=column2 {
+                columns.push(self.evaluate_cell(CellReferenceIndex {
+                    sheet: left.sheet,
+                    row,
+                    column,
+                }));
+            }
+            rows.push(columns);
+        }
+        let shared = Arc::new(rows);
+        self.range_cache.insert(key, shared.clone());
+        shared
+    }
+
+    /// [`range_values`](Self::range_values) for callers that hold loose corner
+    /// coordinates, so they need not build two `CellReferenceIndex` structs.
+    pub(crate) fn range_values_rect(
+        &mut self,
+        sheet: u32,
+        row1: i32,
+        column1: i32,
+        row2: i32,
+        column2: i32,
+    ) -> RangeValues {
+        self.range_values(
+            CellReferenceIndex {
+                sheet,
+                row: row1,
+                column: column1,
+            },
+            CellReferenceIndex {
+                sheet,
+                row: row2,
+                column: column2,
+            },
+        )
+    }
+
     /// Evaluates all cells in a given range and returns the results in a 2D vector.
     pub(crate) fn evaluate_range(
         &mut self,
@@ -1722,6 +1803,7 @@ impl<'a> Model<'a> {
             support: HashMap::new(),
             cf_cache: HashMap::new(),
             links: HashMap::new(),
+            range_cache: HashMap::new(),
         };
 
         model.parse_formulas();
@@ -3034,6 +3116,11 @@ impl<'a> Model<'a> {
     /// Phase 2 evaluates every remaining cell in natural order.  Because all spill areas have
     /// already been written, regular cells always read the correct spill values.
     pub fn evaluate(&mut self) {
+        // The cache is valid only within one pass. A full pass rebuilds every
+        // cell, so clearing here suffices today. If a partial (incremental) pass
+        // is ever added, it must clear or refresh this too, or it will read
+        // stale materialized ranges.
+        self.range_cache.clear();
         self.collect_spill_cells();
 
         let n = self.spill_cells.len();
@@ -3045,6 +3132,9 @@ impl<'a> Model<'a> {
         while retry && restart_count < max_restarts {
             retry = false;
             self.cells.clear();
+            // A restart re-evaluates in a corrected spill order, so ranges
+            // materialized under the old order must not be served from the cache.
+            self.range_cache.clear();
             self.support.clear();
             // dynamic links (HYPERLINK) are rebuilt on every evaluation
             self.links.clear();
@@ -3088,6 +3178,9 @@ impl<'a> Model<'a> {
             });
         }
         self.evaluate_conditional_formatting();
+        // The cache is only valid within this pass; drop it so materialized
+        // ranges are not held resident while the model sits idle.
+        self.range_cache.clear();
     }
 
     /// Removes the content of every cell in the range but leaves the style.

--- a/base/src/new_empty.rs
+++ b/base/src/new_empty.rs
@@ -697,6 +697,7 @@ impl<'a> Model<'a> {
             support: HashMap::new(),
             cf_cache: HashMap::new(),
             links: HashMap::new(),
+            range_cache: HashMap::new(),
         };
         model.parse_formulas();
         model.evaluate_conditional_formatting();

--- a/base/src/test/bench_range_cache.rs
+++ b/base/src/test/bench_range_cache.rs
@@ -1,0 +1,45 @@
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::print_stdout)]
+use crate::Model;
+use std::time::Instant;
+
+// cargo test -p ironcalc_base bench_range_cache --release -- --ignored --nocapture
+//
+// Many formulas aggregate the same range in one pass. With the per-pass cache
+// the range is materialized once; without it every formula re-evaluates every
+// cell in the range. Runs identically on origin/main (no cache) and this branch,
+// so the wall-clock ratio is the cache's effect on this workload.
+#[test]
+#[ignore]
+fn bench_range_cache() {
+    let range_rows = 2000; // cells in the shared range
+    let formulas = 1000; // formulas aggregating it
+    let passes = 10; // full evaluations timed
+
+    let mut model = Model::new_empty("m", "en", "UTC", "en").unwrap();
+    for row in 1..=range_rows {
+        model.set_user_input(0, row, 1, "1".into()).unwrap(); // A1:A{range_rows}
+    }
+    for i in 0..formulas {
+        // C{i} = SUM(A1:A{range_rows}) — all share one range.
+        model
+            .set_user_input(0, i + 1, 3, format!("=SUM(A1:A{range_rows})"))
+            .unwrap();
+    }
+
+    let t = Instant::now();
+    for _ in 0..passes {
+        model.evaluate();
+    }
+    let elapsed = t.elapsed();
+
+    assert_eq!(
+        model.get_formatted_cell_value(0, 1, 3),
+        Ok(range_rows.to_string())
+    );
+    let reads = (range_rows as u64) * (formulas as u64) * (passes as u64);
+    println!(
+        "\n[bench] {formulas} SUM over A1:A{range_rows}, {passes} passes ({reads} logical cell reads)\n        total={elapsed:?} per_pass={:?}\n",
+        elapsed / passes as u32
+    );
+}

--- a/base/src/test/mod.rs
+++ b/base/src/test/mod.rs
@@ -84,6 +84,7 @@ mod test_fn_offset;
 mod test_number_format;
 
 mod array_formulas;
+mod bench_range_cache;
 mod compatibility;
 mod dynamic_evaluation;
 mod logical;
@@ -130,6 +131,7 @@ mod test_networkdays;
 mod test_now;
 mod test_percentage;
 mod test_range_evaluation;
+mod test_range_value_cache;
 mod test_set_functions_error_handling;
 mod test_sheet_names;
 mod test_spill_functions;

--- a/base/src/test/test_range_value_cache.rs
+++ b/base/src/test/test_range_value_cache.rs
@@ -1,0 +1,77 @@
+#![allow(clippy::unwrap_used)]
+
+use crate::test::util::new_empty_model;
+
+#[test]
+fn cache_invalidates_across_passes() {
+    let mut model = new_empty_model();
+    for row in 1..=20 {
+        model._set(&format!("A{row}"), &row.to_string());
+    }
+    for row in 1..=30 {
+        model._set(&format!("C{row}"), "=SUM(A1:A20)");
+    }
+    model.evaluate();
+    for row in 1..=30 {
+        assert_eq!(model._get_text(&format!("C{row}")), "210");
+    }
+
+    model._set("A5", "105");
+    model.evaluate();
+    for row in 1..=30 {
+        assert_eq!(model._get_text(&format!("C{row}")), "310"); // not the stale 210
+    }
+}
+
+#[test]
+fn range_cache_survives_spill_reorder_restart() {
+    let mut model = new_empty_model();
+    model._set("A1", "=SEQUENCE(3)*0 + SUM(B11:B20)");
+    model._set("B10", "={7;8;9}"); // spills B10:B12, so B11=8, B12=9
+    model._set("D1", "=SUM(B11:B20)");
+    model.evaluate();
+    assert_eq!(model._get_text("D1"), "17"); // not the stale 0
+    assert_eq!(model._get_text("A1"), "17");
+}
+
+#[test]
+fn min_over_open_column_ignores_trailing_blanks() {
+    let mut model = new_empty_model();
+    model._set("A1", "5");
+    model._set("A2", "3");
+    model._set("A3", "8");
+    model._set("C1", "=MIN(A:A)");
+    model.evaluate();
+    assert_eq!(model._get_text("C1"), "3");
+}
+
+#[test]
+fn min_over_skip_header_open_range_stays_correct() {
+    let mut model = new_empty_model();
+    model._set("A2", "5");
+    model._set("A3", "3");
+    model._set("C1", "=MIN(A2:A1048576)");
+    model.evaluate();
+    assert_eq!(model._get_text("C1"), "3");
+}
+
+#[test]
+fn lcm_over_skip_header_open_range_sees_trailing_blanks() {
+    let mut model = new_empty_model();
+    model._set("A2", "2");
+    model._set("A3", "3");
+    model._set("A4", "4");
+    model._set("C1", "=LCM(A2:A1048576)");
+    model.evaluate();
+    assert_eq!(model._get_text("C1"), "0"); // trailing blanks count as 0, lcm(_,0)=0
+}
+
+#[test]
+fn countblank_over_open_column_counts_trailing_blanks() {
+    let mut model = new_empty_model();
+    model._set("A1", "1");
+    model._set("A2", "2");
+    model._set("C1", "=COUNTBLANK(A:A)");
+    model.evaluate();
+    assert_eq!(model._get_text("C1"), "1048574"); // whole column minus the two filled
+}

--- a/webapp/IronCalc/package-lock.json
+++ b/webapp/IronCalc/package-lock.json
@@ -39,7 +39,7 @@
       }
     },
     "../../bindings/wasm/pkg": {
-      "name": "@ironcalc/wasm",
+      "name": "wasm",
       "version": "0.8.4",
       "license": "MIT/Apache-2.0"
     },


### PR DESCRIPTION
_Series: #90 incremental engine · #89 changed-cells API (on #90) · #91 range-value cache (independent)._

Aggregate functions read a range one cell at a time, so a column of `=SUM(A1:A2000)` reads the same range once per formula. This adds a `range_values` helper that reads a range once per pass and shares the result, so later reads of the same range in the same pass reuse it. The cache is cleared at the start and end of `evaluate`, and on each spill-reorder restart so a range materialized under a superseded order is never reused, and nothing is held resident while the model is idle.

## Performance

`bench_range_cache` (committed, `#[ignore]`): 1000 `=SUM(A1:A2000)` formulas over one range, 10 passes. The same workload runs on `origin/main` and on this branch, so the cache is the only difference. Apple M1 Pro, release, rustc 1.90.0:

| | per pass |
|---|---|
| origin/main | ~106 ms |
| this branch | ~4 to 5 ms |
| speedup | ~20x |

```
cargo test -p ironcalc_base bench_range_cache --release -- --ignored --nocapture
```

The gain depends on how many formulas share a range in a pass. With no shared ranges there is no change, and the cache lives only for one `evaluate`.

## Correctness

Each converted loop reads the same cells in the same order as before, with the same handling of blanks, booleans, text, and errors. The suite passes (2281), including:

- `cache_invalidates_across_passes`: edit a cell inside a shared range, re-evaluate, and every aggregate updates rather than serve a stale range.
- `range_cache_survives_spill_reorder_restart`: a mid-pass restart clears the cache, so a range materialized under the old spill order is not reused.
- `min_over_open_column_ignores_trailing_blanks` and `countblank_over_open_column_counts_trailing_blanks`: an open column clamps to the used area, and a function that counts blanks still sees the right ones.

Converted: SUM, AVERAGE, COUNT and COUNTA, MIN, MAX, PRODUCT, SUMSQ, the variance and standard-deviation family, SUBTOTAL, MULTINOMIAL, CONCAT, and a date range helper. Left as direct reads: the short-circuiting logicals (AND/OR), which keep streaming so an early exit still avoids the rest of the range, and the functions whose result depends on trailing blanks (the SUMIFS family, COUNTBLANK, TEXTJOIN, GCD/LCM, and NPV/XNPV/XIRR), along with COUNTIFS, the database functions, and the lookup family (VLOOKUP, INDEX, MATCH, XLOOKUP).

## Note

Targets `main` directly, independent of #90 and #89. If it later lands with the incremental path, the partial pass must also clear the cache. This is marked in the code and left for the merge.
