### PR TITLE
Add Cloud Agent development environment for IronCalc

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,23 @@
+{
+  "name": "IronCalc",
+  "install": "./.cursor/install.sh",
+  "terminals": [
+    {
+      "name": "api-server",
+      "command": "cd webapp/app.ironcalc.com/server && cargo run"
+    },
+    {
+      "name": "frontend",
+      "command": "cd webapp/app.ironcalc.com/frontend && npm run dev"
+    },
+    {
+      "name": "caddy",
+      "command": "cd webapp/app.ironcalc.com && caddy run"
+    }
+  ],
+  "ports": [
+    { "name": "webapp", "port": 2080 },
+    { "name": "frontend", "port": 5173 },
+    { "name": "api", "port": 8000 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Idempotent bootstrap for the IronCalc Cloud Agent environment.
+# Prepares the Rust + WASM toolchain and builds every artifact the web app
+# (wasm bindings -> workbook widget -> frontend) and the Rocket API depend on.
+set -euo pipefail
+
+WASM_PACK_VERSION="0.13.1"
+
+echo "==> Ensuring Rust toolchain (stable) and wasm target"
+# A transitive dependency requires the 2024 edition, so the default toolchain
+# must be recent stable rather than whatever the base image ships.
+rustup toolchain install stable --profile minimal --no-self-update >/dev/null 2>&1 || true
+rustup default stable
+rustup target add wasm32-unknown-unknown
+
+echo "==> Ensuring wasm-pack is installed"
+if ! command -v wasm-pack >/dev/null 2>&1; then
+  curl -sSL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz" -o /tmp/wasm-pack.tar.gz
+  tar -xzf /tmp/wasm-pack.tar.gz -C /tmp
+  sudo install -m0755 /tmp/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack /usr/local/bin/wasm-pack
+fi
+
+echo "==> Ensuring caddy is installed"
+if ! command -v caddy >/dev/null 2>&1; then
+  curl -sSL "https://caddyserver.com/api/download?os=linux&arch=amd64" -o /tmp/caddy
+  sudo install -m0755 /tmp/caddy /usr/local/bin/caddy
+fi
+
+echo "==> Building WASM bindings (bindings/wasm/pkg)"
+make -C bindings/wasm
+
+echo "==> Building the workbook widget (@ironcalc/workbook)"
+(cd webapp/IronCalc && npm install && npm run build)
+
+echo "==> Installing frontend app dependencies"
+(cd webapp/app.ironcalc.com/frontend && npm install)
+
+echo "==> Pre-building the Rocket API server"
+(cd webapp/app.ironcalc.com/server && cargo build)
+
+echo "==> Install complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cursor Cloud Agent development environment for IronCalc so the full web application (WASM engine → workbook widget → frontend → Rocket API, proxied by Caddy) runs end to end. The config is committed to the repo, so it is version-controlled and follows branches/PRs (repo-file managed, on Cursor's default base image).

## What's included

- `.cursor/environment.json` — declares the `install` bootstrap, three `terminals` that bring the app up on boot, and exposed ports.
- `.cursor/install.sh` — idempotent, self-sufficient bootstrap that:
  - ensures the Rust `stable` toolchain (the default image's 1.83 is too old — a transitive dependency requires the 2024 edition) and the `wasm32-unknown-unknown` target;
  - ensures `wasm-pack` and `caddy` are installed;
  - builds the WASM bindings (`bindings/wasm/pkg`), the `@ironcalc/workbook` widget, the frontend app dependencies, and pre-builds the Rocket API server.

## Runtime services (terminals)

- `api-server` — `cargo run` in `webapp/app.ironcalc.com/server` (Rocket API on `:8000`)
- `frontend` — `npm run dev` in `webapp/app.ironcalc.com/frontend` (Vite on `:5173`)
- `caddy` — `caddy run` in `webapp/app.ironcalc.com` (proxy on `:2080`, routing `/api/*` → server, everything else → frontend)

The app is served at `http://localhost:2080`.

## Validation

| Check | Result |
| --- | --- |
| Full build pipeline (wasm bindings, widget, frontend, server) | Passed |
| `install.sh` idempotence | Passed (re-run cleanly) |
| Web app loads at `:2080` | HTTP 200, renders spreadsheet |
| Spreadsheet computes formulas end to end | `=SUM(A1:A3)` → 60, `=A5*2` → 120 |
| API round-trip via Caddy (`/api/share` → `/api/model/<hash>` → `/api/list`) | Passed |
| Core Rust tests (`cargo test -p ironcalc_base -p ironcalc`) | Passed |
| Draft build from default image (runs full `install.sh`) | SUCCEEDED |
| Fresh Cloud Agent booted from the build | rustc 1.97.1 stable, wasm-pack, caddy verified; services up; API round-trip passed |

### Demo (formula evaluation in the browser)

[ironcalc_webapp_formula_demo.mp4](https://cursor.com/agents/bc-46c11dd5-4b31-4511-8b51-427dd66af508/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fironcalc_webapp_formula_demo.mp4)

[IronCalc spreadsheet with computed formula results](https://cursor.com/agents/bc-46c11dd5-4b31-4511-8b51-427dd66af508/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fironcalc_formula_result.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-46c11dd5-4b31-4511-8b51-427dd66af508?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-46c11dd5-4b31-4511-8b51-427dd66af508&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

